### PR TITLE
Made display of category menu and categories information optional

### DIFF
--- a/static/css/elegant.css
+++ b/static/css/elegant.css
@@ -260,7 +260,7 @@ article div.article-content ul:not(.articles-timeline) a:hover {
     padding: 5px;
 }
 .page-header h1 {
-    font-size: 3em;
+    font-size: 2em;
     font-weight: normal;
 }
 ul.articles-timeline {

--- a/static/css/elegant.css
+++ b/static/css/elegant.css
@@ -604,3 +604,20 @@ div.figure.align-left, .article-content img.align-left {
     margin-right: 1.5em;
 }
 
+/*added to format byline below header for printed
+ *article pages*/
+#article-byline{
+	font-size: 0.8em;
+}
+
+#article-byline address {
+	display: inline;
+	margin-bottom: 0px;
+	margin-right: 1em;
+}
+
+#article-byline time {
+	display: inline;
+	margin-right: 1em;
+}
+

--- a/static/css/print.css
+++ b/static/css/print.css
@@ -1,0 +1,47 @@
+@media print {
+	/*Page width set to A4
+	 *Height set to 99% to fix blank page at end of document*/
+	html, body {
+    	width: 210mm;
+		height: 99%;
+  	}
+	
+	/*limit maximum image size so images do not 
+	 *exceed page size*/
+	img {
+		max-width: 400px;
+	}
+
+	/*We don't want to print multimedia objects such as
+	 *flash videos, so we'll hide them*/
+	video, audio, object, embed {
+		display: none;
+	}
+
+	/*Hide link urls*/
+	a:after { 
+		display: none;
+	}
+
+	/*Modify bootstrap classes so page header spans
+	 *the full width of the page*/
+	.row-fluid .span10 {
+		width: 100%;
+	}
+
+	/*Modify bootstrap classes so page content spans
+	 *most of the page8*/
+	.row-fluid .span8 {
+		width: 80%;
+	 }	
+
+	/*reduce large left margin*/
+	.row-fluid .offset2:first-child {
+		margin-left: 0.5cm;
+	}
+
+	/*remove blockquote border*/
+	.article-content blockquote {
+		border: none;
+	}
+}

--- a/templates/_includes/article_byline.html
+++ b/templates/_includes/article_byline.html
@@ -1,0 +1,27 @@
+<div id="article-byline" class="visible-print">
+{% if article.authors %}
+	<address class="author">
+	By {% for author in article.authors %}
+		{{ author }}
+	{% endfor %}
+	</address>
+{% endif %}
+
+{% if article.date %}
+	{% set day = article.date.strftime('%d')|int %}
+	Published <time pubdate="pubdate" datetime="{{ article.date.isoformat() }}">{{ article.date.strftime('%b') }} {{   day }} {{- article.date.strftime(', %Y') }}</time>
+{% endif %}
+
+{#  Check which version of Pelican user is using.
+	If it is <=3.3  than modified is a string
+		If it is >3.3 than modified is a datetime object
+#}
+{% if article.locale_modified and article.modified %}
+
+	Last Updated {% set day = article.modified.strftime('%d')|int %}
+	<time datetime="{{ article.modified.isoformat() }}">{{ article.modified.strftime('%b') }} {{ day }} {{- article.modified.strftime(', %Y') }}</time>
+
+	{% elif article.modified %}
+	Last Updated <div class="last-updated">{{ article.modified }}</div>
+{% endif %}
+</div>

--- a/templates/_includes/footer.html
+++ b/templates/_includes/footer.html
@@ -9,7 +9,7 @@
         {% if SITE_LICENSE %}
         <li class="elegant-license">{{ SITE_LICENSE }}</li>
         {% endif %}
-        <li class="elegant-power">Powered by <a href="http://getpelican.com/" title="Pelican Home Page">Pelican</a>. Theme: <a href="http://oncrashreboot.com/pelican-elegant" title="Theme Elegant Home Page">Elegant</a> by <a href="http://oncrashreboot.com" title="Talha Mansoor Home Page">Talha Mansoor</a></li>
+        <li class="elegant-power hidden-print">Powered by <a href="http://getpelican.com/" title="Pelican Home Page">Pelican</a>. Theme: <a href="http://oncrashreboot.com/pelican-elegant" title="Theme Elegant Home Page">Elegant</a> by <a href="http://oncrashreboot.com" title="Talha Mansoor Home Page">Talha Mansoor</a></li>
     </ul>
 </div>
 </footer>

--- a/templates/article.html
+++ b/templates/article.html
@@ -86,10 +86,12 @@
             {% endif %}
             {% include '_includes/last_updated.html' %}
             {% include '_includes/multi_parts.html' %}
+			{% if DISPLAY_CATEGORIES_ON_MENU %}
             {% if article.category|trim|count > 0 %}
             <h4>Category</h4>
             <a class="category-link" href="{{ SITEURL }}/categories.html#{{ category.slug }}-ref">{{ article.category }}</a>
             {% endif %}
+			{% endif %}
             {% if article.tags and article.tags[0]|trim|count > 0 %}
             <h4>Tags</h4>
             <ul class="list-of-tags tags-in-article">

--- a/templates/article.html
+++ b/templates/article.html
@@ -25,9 +25,9 @@
 <div class="row-fluid">
     <header class="page-header span10 offset2">
     <h1><a href="{{ SITEURL }}/{{ article.url }}"> {{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a></h1>
+	{% include '_includes/article_byline.html' %}
     </header>
 </div>
-
 <div class="row-fluid">
     {% if article.toc %}
     <div class="span2 table-of-content">
@@ -78,7 +78,7 @@
             {% endif %}
         </div>
         <section>
-        <div class="span2" style="float:right;font-size:0.9em;">
+        <div class="span2 hidden-print" style="float:right;font-size:0.9em;">
             {% if article.date %}
             <h4>Published</h4>
             {% set day = article.date.strftime('%d')|int %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,15 +33,16 @@
         {% endblock meta_tags_in_head %}
         <title>{% block title %}{{ SITENAME|striptags|e }}{% endblock title %}</title>
         {% block head_links %}
-        <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+        <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet" media="screen,print">
         <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.1/css/font-awesome.css" rel="stylesheet">
         {% if 'assets' in PLUGINS %}
         {% include '_includes/minify_css.html' with context %}
         {% else %}
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/pygments.css" media="screen">
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/tipuesearch/tipuesearch.css" media="screen">
-        <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/elegant.css" media="screen">
+        <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/elegant.css" media="screen,print">
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/custom.css" media="screen">
+        <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/print.css" media="print">
         {% endif %}
         {% endblock head_links %}
         {% include '_includes/favicon_links.html' %}
@@ -52,7 +53,7 @@
     </head>
     <body>
         <div id="content-sans-footer">
-        <div class="navbar navbar-static-top">
+        <div class="navbar navbar-static-top hidden-print">
             <div class="navbar-inner">
                 <div class="container-fluid">
                     <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,9 @@
                             <li {% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
                             {% endfor %}
                             {% endif %}
+							{% if DISPLAY_CATEGORIES_ON_MENU %}
                             <li {% if page_name == 'categories' %} class="active"{% endif %}><a href="{{ SITEURL }}/categories.html">Categories</a></li>
+							{% endif %}
                             <li {% if page_name == 'tags' %} class="active"{% endif %}><a href="{{ SITEURL }}/tags.html">Tags</a></li>
                             <li {% if page_name == 'archives' %} class="active"{% endif %}><a href="{{ SITEURL }}/archives.html">Archives</a></li>
                             <li><form class="navbar-search" action="{{ SITEURL }}/search.html" onsubmit="return validateForm(this.elements['q'].value);"> <input type="text" class="search-query" placeholder="Search" name="q" id="tipue_search_input"></form></li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,6 +95,7 @@
             {% if loop.index0 < RECENT_ARTICLES_COUNT %}
             <article>
                 <a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a>
+				{% if DISPLAY_CATEGORIES_ON_MENU %}
                 <section>
                     posted in
                 <a href="{{ SITEURL }}/categories.html#{{ article.category.slug }}-ref">{{ article.category }}</a>
@@ -102,6 +103,11 @@
                 <time pubdate="pubdate" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
                 </div>
                 </section>
+                {% else %}
+                <div class="recent-posts-time">
+                <small><time pubdate="pubdate" datetime="{{ article.date.isoformat() }}">{{ article.locale_date                }}</time></small>
+                </div>
+                {% endif %}
             </article>
             {% endif %}
             {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -87,7 +87,7 @@
     <div class="row-fluid">
         <div class="{{css_class}}">
             <header>
-            <h1 id="recent-posts">Recent Posts <a id="allposts" href="{{ SITEURL }}/archives.html">all posts</a></h1>
+            <h1 id="recent-posts">Recent Posts <a id="allposts" class="hidden-print" href="{{ SITEURL }}/archives.html">all posts</a></h1>
             </header>
         <div class="recent-posts">
             {% for article in articles %}


### PR DESCRIPTION
The display of the link to the categories page on the main menu and also blog/article category information has been made optional using the variable `DISPLAY_CATEGORIES_ON_MENU` which is used on the standard pelican theme and also on some others.

Some consideration could be given as to whether this setting should be split into two to allow finer control.
- `DISPLAY_CATEGORIES_ON_MENU`
and
- `DISPLAY_CATEGORY_INFORMATION`