### PR TITLE
Changed some URLS from HTTP to HTTPS to prevent mixed-mode-blocking

### DIFF
--- a/templates/_includes/disqus_scripts.html
+++ b/templates/_includes/disqus_scripts.html
@@ -55,6 +55,6 @@ $('#disqus_thread').on('shown', function () {
          (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
      })();
 </script>
-<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-<a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 {% endmacro %}

--- a/templates/_includes/stat_counter.html
+++ b/templates/_includes/stat_counter.html
@@ -11,9 +11,9 @@ scJsHost+
 "statcounter.com/counter/counter.js'></"+"script>");
 </script>
 <noscript><div class="statcounter"><a title="web analytics"
-href="http://statcounter.com/" target="_blank"><img
+href="https://statcounter.com/" target="_blank"><img
 class="statcounter"
-src="http://c.statcounter.com/{{ STAT_COUNTER_PROJECT }}/0/{{ STAT_COUNTER_SECURITY }}/1/"
+src="https://c.statcounter.com/{{ STAT_COUNTER_PROJECT }}/0/{{ STAT_COUNTER_SECURITY }}/1/"
 alt="web analytics"></a></div></noscript>
 <!-- End of StatCounter Code for Default Guide -->
 {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -100,7 +100,7 @@
     </div>
 {% include '_includes/footer.html' %}
 {% block script %}
-<script src="http://code.jquery.com/jquery.min.js"></script>
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 <script>
 function validateForm(query)

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,8 +33,8 @@
 {% endblock meta_tags_in_head %}
 <title>{% block title %}{{ SITENAME|striptags|e }}{% endblock title %}</title>
 {% block head_links %}
-<link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
-<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 {% if 'assets' in PLUGINS %}
 {% include '_includes/minify_css.html' with context %}
 {% else %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -42,8 +42,10 @@
             {% endif %}
 
             {{ page.content }}
+            {% if not DISABLE_PAGE_COMMENTS %}
             {% from '_includes/comments.html' import comments with context %}
             {{ comments(page) }}
+            {% endif %}
         </div>
         <section>
         <div class="col-md-2" style="float:right;font-size:0.9em;">
@@ -57,6 +59,8 @@
 
     {% block script %}
     {{ super() }}
+    {% if not DISABLE_PAGE_COMMENTS %}
     {% from '_includes/comments.html' import comments_script with context %}
     {{ comments_script(page) }}
+    {% endif %}
     {% endblock script %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -25,7 +25,7 @@ Search results for {{ SITENAME|striptags|e }} blog.
 {% endblock meta_tags_in_head %}
 
 {% block script %}
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
     {% if 'assets' in PLUGINS %}
     {% include '_includes/minify_tipuesearch.html' with context %}
     {% else %}


### PR DESCRIPTION
In Firefox, content transmitted via HTTP gets blocked if the base url is called via HTTPS. Let's change the calls for <script>'s and so on to HTTPs to prevent this.
